### PR TITLE
Change absolute path to relative for routers page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ module.exports = {
           position: "left",
         },
         {
-          href: "Routers/intro",
+          href: "/Routers/intro",
           label: "Routers",
           position: "left",
         },


### PR DESCRIPTION
I find out that url for routers is not working correctly because it is a relative path not absolute.
For example if you go to page https://docs.connext.network/Integration/SystemOverview/connextvsxyz and when click the Routers button in the top of the page you will be moved to https://docs.connext.network/Integration/SystemOverview/Routers/intro instead of https://docs.connext.network/Routers/intro
Here the PR, that i hope will fix this.