### PR TITLE
Update example of router version in config

### DIFF
--- a/docs/Routers/spinning-up.md
+++ b/docs/Routers/spinning-up.md
@@ -43,7 +43,7 @@ Create a `.env` file in the root directory of the repository based on the `env.e
 
 Modify the following environment variables:
 
-* `ROUTER_VERSION` - The version of the router to use (e.g. `v0.1.0`). See the [releases page](https://github.com/connext/nxtp/releases) for the latest released version.
+* `ROUTER_VERSION` - The version of the router to use (e.g. `0.2.0-alpha.16`). See the [releases page](https://github.com/connext/nxtp/releases) for the latest released version.
 * `ROUTER_EXTERNAL_PORT` - Exposed port of the router. Remember to not expose this port to the public.
 * `GRAFANA_EXTERNAL_PORT` - Exposed port of the Grafana dashboard.
 * `LOGDNA_KEY` - This key is used by logna container. You can get this key by sign up [here](https://app.logdna.com/)


### PR DESCRIPTION
I got stucked by the mismatch version of router image when spin my router because there is no prefix `v` in docker image tag. Update the documentation to clarify it.