### PR TITLE
Update key.yaml file name of web3signer

### DIFF
--- a/docs/routers/spinning-up.md
+++ b/docs/routers/spinning-up.md
@@ -54,7 +54,7 @@ The router uses an internal Redis instance in Docker by default. However, if you
 
 ### Web3Signer Config
 
-Set up [Web3Signer](https://docs.web3signer.consensys.net/en/latest/) config files to set the private key securely. Fill the private key of your signer to `key.example.yaml`.
+Set up [Web3Signer](https://docs.web3signer.consensys.net/en/latest/) config files to set the private key securely. Create a key.yaml file based on the key.example.yaml file. Fill the private key of your signer to `key.yaml`.
 
 ### Router Config
 


### PR DESCRIPTION
We use `key.yaml` file name in docker compose.
https://github.com/connext/nxtp-router-docker-compose/blob/213d15ea46bbb715900ba01f47ca5b1ace9802bb/docker-compose.yml#L33