### PR TITLE
fixing documentation link

### DIFF
--- a/docs/developers/intro.md
+++ b/docs/developers/intro.md
@@ -32,7 +32,7 @@ Deployed contract addresses, domain IDs, and other useful information can be fou
 
 Specific questions might be answered in the FAQ.
 
-[FAQ](./faq)
+[FAQ](../faq)
 
 Have other questions or need support? Our core team and vibrant community members are highly active in our Discord server!
 


### PR DESCRIPTION
the faq link is incorrect on the main page.

after - linking to `/faq`:

<img width="1785" alt="Screen Shot 2022-07-07 at 10 05 36 AM" src="https://user-images.githubusercontent.com/5998100/177820220-ad1ca925-0ad5-49a9-845f-3933bbecab1f.png">


before - linking to `/developer/faq`:

<img width="1786" alt="Screen Shot 2022-07-07 at 10 05 17 AM" src="https://user-images.githubusercontent.com/5998100/177820134-316fe61b-f1ea-4918-9ba6-7f7663464e5e.png">
