### PR TITLE
Add outer braces to package.json of "Cross-Chain Transfer" example

### DIFF
--- a/docs/developers/sdk/sdk-quickstart.md
+++ b/docs/developers/sdk/sdk-quickstart.md
@@ -53,10 +53,12 @@ We want to use top-level await so we'll set the compiler options accordingly.
 And add the following to `package.json`:
 
 ```json title="package.json"
-"type": "module",
-"scripts": {
-  "build": "tsc && node dist/xtransfer.js",
-  "xtransfer": "node dist/xtransfer.js"
+{
+  "type": "module",
+  "scripts": {
+    "build": "tsc && node dist/xtransfer.js",
+    "xtransfer": "node dist/xtransfer.js"
+  }
 }
 ```
 


### PR DESCRIPTION
This is required in order to have a valid JSON file.
Otherwise there is a JSON parsing error when attempting to install the @connext/nxtp-sdk dependency.
