### PR TITLE
Revert "Add outer braces to package.json of "Cross-Chain Transfer" example"

### DIFF
--- a/docs/developers/sdk/sdk-quickstart.md
+++ b/docs/developers/sdk/sdk-quickstart.md
@@ -53,12 +53,10 @@ We want to use top-level await so we'll set the compiler options accordingly.
 And add the following to `package.json`:
 
 ```json title="package.json"
-{
-  "type": "module",
-  "scripts": {
-    "build": "tsc && node dist/xtransfer.js",
-    "xtransfer": "node dist/xtransfer.js"
-  }
+"type": "module",
+"scripts": {
+  "build": "tsc && node dist/xtransfer.js",
+  "xtransfer": "node dist/xtransfer.js"
 }
 ```
 


### PR DESCRIPTION
Revert connext/documentation#74 as the original snippet is meant to be additive and hence ok in its original form.