### PR TITLE
fix: broken edit url link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,7 +105,7 @@ module.exports = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: true,
-          editUrl: "https://github.com/connext/documentation",
+          editUrl: "https://github.com/connext/documentation/blob/main",
           lastVersion: "current",
           remarkPlugins: [
             CardLink,


### PR DESCRIPTION
Currently points to [this](https://github.com/connext/documentation/docs/developers/quickstart.mdx) and it should point to [this](https://github.com/connext/documentation/blob/main/docs/developers/quickstart.mdx)